### PR TITLE
Use sh shell in order to use on minimal system

### DIFF
--- a/bbb-check-phy
+++ b/bbb-check-phy
@@ -1,4 +1,4 @@
-#! /bin/bash
+#! /bin/sh
 
 # first we sleep.
 # this gives plently of time for linux to mess with the RTC
@@ -11,7 +11,7 @@
 
 sleep 30
 
-if [[ $(phyreg test 18 13) == "1" ]]; then
+if [ "$(phyreg test 18 13)" = "1" ]; then
 
 	sleep 1
 

--- a/chkphy
+++ b/chkphy
@@ -1,4 +1,4 @@
-#! /bin/bash
+#! /bin/sh
 
 ### BEGIN INIT INFO
 # Provides:          chkphy


### PR DESCRIPTION
Hi @bigjosh 
Thank you very much for all your work to workaround this BBB issue.
In order to use it on a minimal system built with Buildroot, I have ported the onboard scripts to use `sh` instead of `bash`.